### PR TITLE
Add Visual Studio Code configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceRoot}/node_modules/probot/bin/probot-run",
+            "args": [
+                "./index.js"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Add launch configuration for Visual Studio Code so that debugging works properly. The `probot-run` "binary" has to be referenced directly since, when using `probot run` (no `-`), `commander` spawns a new process, which the debugger doesn't know about, to run subcommands indirectly.