### PR TITLE
Update Travis CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A GitHub Integration built with [probot](https://github.com/probot/probot) that enforces GPG signatures on Pull Requests
 
-[![Build Status](https://travis-ci.org/jarrodldavis/probot-gpg.svg)](https://travis-ci.org/jarrodldavis/probot-gpg)
+[![Build Status](https://travis-ci.org/jarrodldavis/probot-gpg.svg?branch=develop)](https://travis-ci.org/jarrodldavis/probot-gpg)
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A GitHub Integration built with [probot](https://github.com/probot/probot) that enforces GPG signatures on Pull Requests
 
-[![Build Status](https://travis-ci.com/jarrodldavis/probot-gpg.svg?token=kt4sesdfXg3h6zxmjGuo&branch=develop)](https://travis-ci.com/jarrodldavis/probot-gpg)
+[![Build Status](https://travis-ci.org/jarrodldavis/probot-gpg.svg)](https://travis-ci.org/jarrodldavis/probot-gpg)
 
 ## Setup
 


### PR DESCRIPTION
Update the Travis CI badge to use [travis-ci.org](travis-ci.org).