### PR TITLE
Add Code Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
   - "7.7.1"
 notifications:
   disabled: true
+after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > A GitHub Integration built with [probot](https://github.com/probot/probot) that enforces GPG signatures on Pull Requests
 
 [![Build Status](https://travis-ci.org/jarrodldavis/probot-gpg.svg?branch=develop)](https://travis-ci.org/jarrodldavis/probot-gpg)
+[![Coverage Status](https://coveralls.io/repos/github/jarrodldavis/probot-gpg/badge.svg)](https://coveralls.io/github/jarrodldavis/probot-gpg)
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/jarrodldavis/probot-gpg.git",
   "scripts": {
     "start": "probot run ./index.js",
-    "test": "xo && mocha"
+    "test": "xo && nyc mocha"
   },
   "dependencies": {
     "probot": "~0.4.0"
@@ -17,6 +17,7 @@
     "expect": "^1.20.2",
     "localtunnel": "^1.8.2",
     "mocha": "^3.2.0",
+    "nyc": "^10.3.2",
     "proxyquire": "^1.8.0",
     "xo": "^0.18.0"
   },

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
   "repository": "https://github.com/jarrodldavis/probot-gpg.git",
   "scripts": {
     "start": "probot run ./index.js",
-    "test": "xo && nyc mocha"
+    "test": "xo && nyc mocha",
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
     "probot": "~0.4.0"
   },
   "devDependencies": {
+    "coveralls": "^2.13.1",
     "eslint-config-probot": ">=0.1.0",
     "expect": "^1.20.2",
     "localtunnel": "^1.8.2",


### PR DESCRIPTION
Add code coverage tracking and reporting via Istanbul (`nyc`) and [Coveralls](https://coveralls.io).