### PR TITLE
Narrow handled webhook event/actions

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -23,7 +23,7 @@ module.exports = class Plugin extends events.EventEmitter {
     }
 
     this.robot = robot
-    this.robot.on('pull_request', async context => this.acceptEvent(context))
+    this.robot.on(['pull_request.opened', 'pull_request.synchronize'], async context => this.acceptEvent(context))
 
     this.robot.log.debug(prefix + 'Registered webhook event handlers.')
 


### PR DESCRIPTION
Filter `pull_request` actions to only `opened` and `synchronize`, since
other actions are just noise.