### PR TITLE
Use bunyan directly

### DIFF
--- a/lib/create-status.js
+++ b/lib/create-status.js
@@ -20,7 +20,8 @@ module.exports = async (context, gpgStatus) => {
     context: 'GPG'
   }
 
-  context.log.debug(`Setting status ${gpgStatus} on commit ${statusParams.sha}`)
+  const log = context.log.child({ status: gpgStatus, sha: statusParams.sha })
+  log.debug('Applying status')
 
   switch (gpgStatus) {
     case 'success':
@@ -36,5 +37,5 @@ module.exports = async (context, gpgStatus) => {
 
   await context.github.repos.createStatus(context.repo(statusParams))
 
-  context.log.info(`Status ${gpgStatus} applied to commit ${statusParams.sha}`)
+  log.info('Status applied')
 }

--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -3,11 +3,16 @@ module.exports = async function (context) {
   const base = pullRequest.base.sha
   const head = pullRequest.head.sha
 
-  context.log.debug(`Retrieving commits for comparison ${base}...${head}`)
+  context.log.debug({ base, head }, 'Retrieving commits')
 
   const response = await context.github.repos.compareCommits(context.repo({ base, head }))
 
-  context.log.debug(`Retrieved ${response.data.commits.length} commits for comparison ${base}...${head}`)
+  context.log.debug({
+    base,
+    head,
+    count: response.data.commits.length,
+    commits: response.data.commits.map(commit => commit.sha)
+  }, 'Retrieved commits')
 
   return response.data.commits
 }

--- a/lib/gpg-context.js
+++ b/lib/gpg-context.js
@@ -1,20 +1,15 @@
 const Context = require('probot/lib/context')
 
 module.exports = class GpgEventContext extends Context {
-  constructor (robot, context) {
+  constructor (log, context) {
     super(context, context.github)
 
-    const event = this.event
-    const action = this.payload.action
-    const repo = this.payload.repository.full_name
-    const number = this.payload.number
-    const logPrefix = `[GPG] {${event}.${action}@${repo}#${number}} (${this.id})`
-
-    this.log = Object
-      .entries(robot.log)
-      .reduce((obj, [level, fn]) => {
-        obj[level] = message => fn(`${logPrefix}\n${message}`)
-        return obj
-      }, {})
+    this.log = log.child({
+      event: this.event,
+      action: this.payload.action,
+      repo: this.payload.repository.full_name,
+      number: this.payload.number,
+      webhook: this.id
+    })
   }
 }

--- a/lib/handle-event.js
+++ b/lib/handle-event.js
@@ -12,14 +12,14 @@ module.exports = async context => {
     const statusChain = commits.map(commit => validateCommit(context, commit))
     status = reduceStatuses(context, statusChain)
   } catch (err) {
-    context.log.error(`An error occurred during validation. ${err.name}: ${err.message}`)
+    context.log.error({ err }, 'An error occurred during validation')
     status = 'error'
   }
 
   try {
     await createStatus(context, status)
   } catch (err) {
-    context.log.error(`An error occurred during status creation. ${err.name}: ${err.message}`)
+    context.log.error({ err }, 'An error occurred during status creation')
   }
 
   context.log.debug('Event handled')

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,5 @@
 const events = require('events')
+const bunyan = require('bunyan')
 
 const GpgEventContext = require('./gpg-context')
 const handleEvent = require('./handle-event')
@@ -6,26 +7,27 @@ const handleEvent = require('./handle-event')
 module.exports = class Plugin extends events.EventEmitter {
   constructor () {
     super()
+    this.log = bunyan.createLogger({
+      name: 'GPG',
+      level: process.env.LOG_LEVEL || 'debug',
+      serializers: bunyan.stdSerializers
+    })
     this.robot = null
   }
 
   load (robot) {
-    const prefix = '[GPG] {plugin.load}\n'
     if (!(this instanceof Plugin)) {
-      robot.log.error(prefix + 'Unexpected execution context for method call')
       throw new TypeError('Unexpected execution context for method call')
     }
 
     if (this.robot !== null) {
-      robot.log.error(prefix + 'Plugin instance has already been loaded')
-      this.robot.log.error(prefix + 'Plugin instance has already been loaded')
       this.emit('error', new Error('Plugin instance has already been loaded'))
     }
 
     this.robot = robot
     this.robot.on(['pull_request.opened', 'pull_request.synchronize'], async context => this.acceptEvent(context))
 
-    this.robot.log.debug(prefix + 'Registered webhook event handlers.')
+    this.log.debug('Registered webhook event handlers.')
 
     this.emit('loaded')
   }
@@ -41,7 +43,7 @@ module.exports = class Plugin extends events.EventEmitter {
     }
 
     try {
-      await handleEvent(new GpgEventContext(this.robot, context))
+      await handleEvent(new GpgEventContext(this.log, context))
       this.emit('event-handled')
     } catch (err) {
       this.emit('error', err)

--- a/lib/reduce-statuses.js
+++ b/lib/reduce-statuses.js
@@ -1,5 +1,5 @@
 module.exports = function (context, statusChain) {
-  context.log.debug(`Reducing status chain [${statusChain.join(', ')}]`)
+  context.log.debug({ statusChain }, 'Reducing status chain')
 
   const reduced = statusChain.reduce((overallStatus, currentStatus) => {
     if (currentStatus === 'error' || overallStatus === 'error') {
@@ -13,7 +13,7 @@ module.exports = function (context, statusChain) {
     return currentStatus
   })
 
-  context.log.debug(`Reduced status chain to ${reduced}`)
+  context.log.debug({ reduced }, 'Reduced status chain')
 
   return reduced
 }

--- a/lib/validate-commit.js
+++ b/lib/validate-commit.js
@@ -1,16 +1,17 @@
 module.exports = function (context, commit) {
-  context.log.debug(`Verifying commit ${commit.sha}`)
+  const log = context.log.child({ sha: commit.sha })
+  log.debug('Verifying commit')
 
   if (commit.commit.verification === undefined) {
-    context.log.error(`Commit ${commit.sha} has no verification information`)
+    log.error('Commit has no verification information')
     return 'error'
   }
 
   if (commit.commit.verification.verified === true) {
-    context.log.debug(`Commit ${commit.sha} has passed verification`)
+    log.debug('Commit has passed verification')
     return 'success'
   }
 
-  context.log.info(`Commit ${commit.sha} has failed verification`)
+  context.log.info({ reason: commit.commit.verification.reason }, 'Commit has failed verification')
   return 'failure'
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lt": "lt --port 3000"
   },
   "dependencies": {
+    "bunyan": "^1.8.12",
     "probot": "~3.0.0"
   },
   "devDependencies": {

--- a/test/mocks/robot.js
+++ b/test/mocks/robot.js
@@ -1,10 +1,4 @@
-const createLogStubs = require('../utils/create-log-stubs')
-
 module.exports = class RobotMock {
-  constructor () {
-    this.log = createLogStubs()
-  }
-
   on () {
     return this
   }

--- a/test/utils/create-log-stubs.js
+++ b/test/utils/create-log-stubs.js
@@ -1,8 +1,12 @@
 const sinon = require('sinon')
 
-module.exports = () =>
-  ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+module.exports = () => {
+  let log = {}
+  log.child = () => log
+
+  return ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
     .reduce((obj, level) => {
       obj[level] = sinon.stub()
       return obj
-    }, {})
+    }, log)
+}


### PR DESCRIPTION
Instead of using the wrapped logger from `Robot`, use `bunyan` directly in the plugin and event context. This allows for more structured logging instead of relying on (hopefully) consistent log formats and prefixes.